### PR TITLE
Update getFilesMatchingGlob to follow symlinks

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -37,7 +37,7 @@ module.exports = {
 		const project = this.getClosestLikelyReactNativeProjectPath();
 		if (!project) return callback(new Error('Unable to find project path.'));
 
-		glob(path.join(project, pattern), (err, files) => {
+		glob(path.join(project, pattern), { follow: true }, (err, files) => {
 			if (err) return callback(err);
 
             // Go through each project.


### PR DESCRIPTION
Will fix the usecase for people having shared dependencies with linklocal for example

<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Glob will now follow symlinks inside node_modules
