### PR TITLE
Fixing syntax error with single quotes

### DIFF
--- a/lib/react-native-xcode.sh
+++ b/lib/react-native-xcode.sh
@@ -107,7 +107,7 @@ eval 'case "$CONFIGURATION" in
     PLIST=$TARGET_BUILD_DIR/$INFOPLIST_PATH
     IP=$(ipconfig getifaddr en0)
     if [ -z "$IP" ]; then
-      IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | cut -d\   -f2  | awk 'NR==1{print $1}')
+      IP=$(ifconfig | grep "inet " | grep -v " 127." | cut -d\   -f2  | awk "NR==1{print $1}")
     fi
 
     if [ -z ${DISABLE_XIP+x} ]; then


### PR DESCRIPTION
## Description of changes

Fixing issue where physical device via USB cannot open debugger due to syntax error (unable to parse IP).

The affected code block is already contained in single quotes, so the existing single quotes are causing a syntax error and the IP is not being found (defaulting to 127.0.0.1, aka simulator).


## Related issues (if any)

