### PR TITLE
Re-add plus sign to devConfigs to allow debug configurations

### DIFF
--- a/src/fix-script.js
+++ b/src/fix-script.js
@@ -21,7 +21,7 @@ function updateProject (project) {
 			const nodeCommand = scriptSettings.nodeCommand ? scriptSettings.nodeCommand + ' ' : '';
 			const env = scriptSettings.env || [];
 
-			const devConfigs = `\\"(${configurations}${configurations.length ? '|' : ''}Debug)\\"`;
+			const devConfigs = `\\"+(${configurations}${configurations.length ? '|' : ''}Debug)\\"`;
 			env.DEVELOPMENT_BUILD_CONFIGURATIONS = devConfigs;
 			env.NODE_BINARY = env.NODE_BINARY || 'node';
 


### PR DESCRIPTION
## Description of changes
Re-add plus sign to devConfigs to allow debug configurations. Everything was being treated as release.


## Related issues (if any)
#42 
